### PR TITLE
WIP: Improve formatting for AssignmentExpression with ClassExpression that has long superClass

### DIFF
--- a/changelog_unreleased/javascript/pr-9341.md
+++ b/changelog_unreleased/javascript/pr-9341.md
@@ -1,0 +1,31 @@
+#### Improve formatting for `AssignmentExpression` with `ClassExpression` that has a long super class (#9341 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```js
+// Input
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
+  aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1
+) {
+  method () {
+    console.log("foo");
+  }
+};
+
+// Prettier stable
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends aaaaaaaa
+  .bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1 {
+  method() {
+    console.log("foo");
+  }
+};
+
+// Prettier master
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
+  aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1
+) {
+  method() {
+    console.log("foo");
+  }
+};
+
+```

--- a/changelog_unreleased/javascript/pr-9341.md
+++ b/changelog_unreleased/javascript/pr-9341.md
@@ -1,5 +1,7 @@
 #### Improve formatting for `AssignmentExpression` with `ClassExpression` that has a long super class (#9341 by @sosukesuzuki)
 
+This improves the formatting for [Google Closure Library Namespace](https://developers.google.com/closure/library/docs/introduction#names).
+
 <!-- prettier-ignore -->
 ```js
 // Input

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4323,7 +4323,8 @@ function printClass(path, options, print) {
         return concat([
           ifBreak("("),
           indent(concat([softline, printed])),
-          concat([softline, ifBreak(")")]),
+          softline,
+          ifBreak(")"),
         ]);
       }
       return printed;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4316,9 +4316,21 @@ function printClass(path, options, print) {
   }
 
   if (n.superClass) {
+    const printSuperClass = (path) => {
+      const printed = path.call(print, "superClass");
+      const parent = path.getParentNode();
+      if (parent && parent.type === "AssignmentExpression") {
+        return concat([
+          ifBreak("("),
+          indent(concat([softline, printed])),
+          concat([softline, ifBreak(")")]),
+        ]);
+      }
+      return printed;
+    };
     const printed = concat([
       "extends ",
-      path.call(print, "superClass"),
+      printSuperClass(path),
       path.call(print, "superTypeParameters"),
     ]);
     const printedWithComments = path.call(

--- a/tests/js/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/classes/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`assignment.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
+  aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1
+) {
+  method () {
+    console.log("foo");
+  }
+};
+
+foo = class extends bar {
+  method() {
+    console.log("foo");
+  }
+};
+
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends bar {
+  method() {
+    console.log("foo");
+  }
+};
+
+foo = class extends aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 {
+  method() {
+    console.log("foo");
+  }
+};
+
+=====================================output=====================================
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
+  aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1
+) {
+  method() {
+    console.log("foo");
+  }
+};
+
+foo = class extends (
+  bar
+) {
+  method() {
+    console.log("foo");
+  }
+};
+
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
+  bar
+) {
+  method() {
+    console.log("foo");
+  }
+};
+
+foo = class extends (
+  aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2
+) {
+  method() {
+    console.log("foo");
+  }
+};
+
+================================================================================
+`;
+
 exports[`binary.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/js/classes/assignment.js
+++ b/tests/js/classes/assignment.js
@@ -1,0 +1,25 @@
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
+  aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1
+) {
+  method () {
+    console.log("foo");
+  }
+};
+
+foo = class extends bar {
+  method() {
+    console.log("foo");
+  }
+};
+
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends bar {
+  method() {
+    console.log("foo");
+  }
+};
+
+foo = class extends aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 {
+  method() {
+    console.log("foo");
+  }
+};


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

**Input:**
```js
aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
  aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1
) {
  method () {
    console.log("foo");
  }
};

```

**Prettier stable:**
```js
aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends aaaaaaaa
  .bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1 {
  method() {
    console.log("foo");
  }
};

```

**This PR:**
```js
aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
  aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1
) {
  method() {
    console.log("foo");
  }
};

```

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
