### PR TITLE
Finding heuristics for TS classes that has broken heritage clause

### DIFF
--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -149,9 +149,14 @@ function printList(path, options, print, listName, groupId) {
     printedLeadingComments,
     printedLeadingComments && hardline,
     listName,
-    group(indent([line, join([",", line], path.map(print, listName))]), {
-      id: groupId,
-    }),
+    group(
+      indent([line, join([",", line], path.map(print, listName))]),
+      groupId
+        ? {
+            id: groupId,
+          }
+        : undefined
+    ),
   ];
 }
 

--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -68,7 +68,9 @@ function printClass(path, options, print) {
   }
 
   extendsParts.push(printList(path, options, print, "mixins"));
-  extendsParts.push(printList(path, options, print, "implements"));
+  extendsParts.push(
+    printList(path, options, print, "implements", getImplementsGroupId(n))
+  );
 
   if (groupMode) {
     const printedExtends = extendsParts;
@@ -99,6 +101,14 @@ function getHeritageGroupId(node) {
   return heritageGroupIds.get(node);
 }
 
+const implementsGroupIds = new WeakMap();
+function getImplementsGroupId(node) {
+  if (!implementsGroupIds.has(node)) {
+    implementsGroupIds.set(node, Symbol("implementsGroup"));
+  }
+  return implementsGroupIds.get(node);
+}
+
 function hasMultipleHeritage(node) {
   return (
     ["superClass", "extends", "mixins", "implements"].filter(
@@ -118,7 +128,7 @@ function shouldIndentOnlyHeritageClauses(node) {
   );
 }
 
-function printList(path, options, print, listName) {
+function printList(path, options, print, listName, groupId) {
   const n = path.getValue();
   if (!isNonEmptyArray(n[listName])) {
     return "";
@@ -139,7 +149,9 @@ function printList(path, options, print, listName) {
     printedLeadingComments,
     printedLeadingComments && hardline,
     listName,
-    group(indent([line, join([",", line], path.map(print, listName))])),
+    group(indent([line, join([",", line], path.map(print, listName))]), {
+      id: groupId,
+    }),
   ];
 }
 
@@ -232,4 +244,5 @@ module.exports = {
   printClassMethod,
   printClassProperty,
   getHeritageGroupId,
+  getImplementsGroupId,
 };

--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -72,15 +72,16 @@ function printClass(path, options, print) {
 
   if (groupMode) {
     const printedExtends = extendsParts;
+    let printedPartsGroup;
     if (shouldIndentOnlyHeritageClauses(n)) {
-      parts.push(
-        group(
-          partsGroup.concat(ifBreak(indent(printedExtends), printedExtends))
-        )
-      );
+      printedPartsGroup = [
+        ...partsGroup,
+        ifBreak(indent(printedExtends), printedExtends),
+      ];
     } else {
-      parts.push(group(indent(partsGroup.concat(printedExtends))));
+      printedPartsGroup = indent([...partsGroup, printedExtends]);
     }
+    parts.push(group(printedPartsGroup, { id: getExtendsGroupId(n) }));
   } else {
     parts.push(...partsGroup, ...extendsParts);
   }
@@ -88,6 +89,14 @@ function printClass(path, options, print) {
   parts.push(" ", path.call(print, "body"));
 
   return parts;
+}
+
+const extendsGroupIds = new WeakMap();
+function getExtendsGroupId(node) {
+  if (!extendsGroupIds.has(node)) {
+    extendsGroupIds.set(node, Symbol("extendsGroup"));
+  }
+  return extendsGroupIds.get(node);
 }
 
 function hasMultipleHeritage(node) {
@@ -222,4 +231,5 @@ module.exports = {
   printClass,
   printClassMethod,
   printClassProperty,
+  getExtendsGroupId,
 };

--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -81,7 +81,7 @@ function printClass(path, options, print) {
     } else {
       printedPartsGroup = indent([...partsGroup, printedExtends]);
     }
-    parts.push(group(printedPartsGroup, { id: getExtendsGroupId(n) }));
+    parts.push(group(printedPartsGroup, { id: getHeritageGroupId(n) }));
   } else {
     parts.push(...partsGroup, ...extendsParts);
   }
@@ -91,12 +91,12 @@ function printClass(path, options, print) {
   return parts;
 }
 
-const extendsGroupIds = new WeakMap();
-function getExtendsGroupId(node) {
-  if (!extendsGroupIds.has(node)) {
-    extendsGroupIds.set(node, Symbol("extendsGroup"));
+const heritageGroupIds = new WeakMap();
+function getHeritageGroupId(node) {
+  if (!heritageGroupIds.has(node)) {
+    heritageGroupIds.set(node, Symbol("heritageGroup"));
   }
-  return extendsGroupIds.get(node);
+  return heritageGroupIds.get(node);
 }
 
 function hasMultipleHeritage(node) {
@@ -231,5 +231,5 @@ module.exports = {
   printClass,
   printClassMethod,
   printClassProperty,
-  getExtendsGroupId,
+  getHeritageGroupId,
 };

--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -39,7 +39,11 @@ function printStatementSequence(path, options, print, property) {
 
     const printed = print(path);
 
-    if (index === 0 && isClassBody) {
+    if (
+      index === 0 &&
+      isClassBody &&
+      !hasComment(node, CommentCheckFlags.Leading)
+    ) {
       parts.push(
         ifBreak(hardline, "", { groupId: getExtendsGroupId(classNode) })
       );

--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -25,7 +25,6 @@ function printStatementSequence(path, options, print, property) {
   const node = path.getValue();
   const parts = [];
   const isClassBody = node.type === "ClassBody";
-  const classNode = isClassBody && path.getParentNode();
   const lastStatement = getLastStatement(node[property]);
 
   path.each((path, index, statements) => {
@@ -44,6 +43,7 @@ function printStatementSequence(path, options, print, property) {
       isClassBody &&
       !hasComment(node, CommentCheckFlags.Leading)
     ) {
+      const classNode = path.getParentNode(1);
       parts.push(
         ifBreak(
           ifBreak("", hardline, { groupId: getImplementsGroupId(classNode) }),

--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -14,7 +14,7 @@ const {
   isNextLineEmpty,
 } = require("../utils");
 const { shouldPrintParamsWithoutParens } = require("./function");
-const { getExtendsGroupId } = require("./class");
+const { getHeritageGroupId } = require("./class");
 
 /**
  * @typedef {import("../../document").Doc} Doc
@@ -45,7 +45,7 @@ function printStatementSequence(path, options, print, property) {
       !hasComment(node, CommentCheckFlags.Leading)
     ) {
       parts.push(
-        ifBreak(hardline, "", { groupId: getExtendsGroupId(classNode) })
+        ifBreak(hardline, "", { groupId: getHeritageGroupId(classNode) })
       );
     }
 

--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const {
-  builders: { hardline },
+  builders: { hardline, ifBreak },
 } = require("../../document");
 const pathNeedsParens = require("../needs-parens");
 const {
@@ -14,6 +14,7 @@ const {
   isNextLineEmpty,
 } = require("../utils");
 const { shouldPrintParamsWithoutParens } = require("./function");
+const { getExtendsGroupId } = require("./class");
 
 /**
  * @typedef {import("../../document").Doc} Doc
@@ -24,6 +25,7 @@ function printStatementSequence(path, options, print, property) {
   const node = path.getValue();
   const parts = [];
   const isClassBody = node.type === "ClassBody";
+  const classNode = isClassBody && path.getParentNode();
   const lastStatement = getLastStatement(node[property]);
 
   path.each((path, index, statements) => {
@@ -36,6 +38,12 @@ function printStatementSequence(path, options, print, property) {
     }
 
     const printed = print(path);
+
+    if (index === 0 && isClassBody) {
+      parts.push(
+        ifBreak(hardline, "", { groupId: getExtendsGroupId(classNode) })
+      );
+    }
 
     // in no-semi mode, prepend statement with semicolon if it might break ASI
     // don't prepend the only JSX element in a program with semicolon

--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -14,7 +14,7 @@ const {
   isNextLineEmpty,
 } = require("../utils");
 const { shouldPrintParamsWithoutParens } = require("./function");
-const { getHeritageGroupId } = require("./class");
+const { getHeritageGroupId, getImplementsGroupId } = require("./class");
 
 /**
  * @typedef {import("../../document").Doc} Doc
@@ -45,7 +45,11 @@ function printStatementSequence(path, options, print, property) {
       !hasComment(node, CommentCheckFlags.Leading)
     ) {
       parts.push(
-        ifBreak(hardline, "", { groupId: getHeritageGroupId(classNode) })
+        ifBreak(
+          ifBreak("", hardline, { groupId: getImplementsGroupId(classNode) }),
+          "",
+          { groupId: getHeritageGroupId(classNode) }
+        )
       );
     }
 

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -5,8 +5,6 @@ const {
   getLast,
   hasNewline,
   hasNewlineInRange,
-  skipNewline,
-  skipSpaces,
   skipWhitespace,
   isNonEmptyArray,
   isNextLineEmptyAfterIndex,

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -5,6 +5,8 @@ const {
   getLast,
   hasNewline,
   hasNewlineInRange,
+  skipNewline,
+  skipSpaces,
   skipWhitespace,
   isNonEmptyArray,
   isNextLineEmptyAfterIndex,

--- a/tests/typescript/class-comment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/class-comment/__snapshots__/jsfmt.spec.js.snap
@@ -84,6 +84,7 @@ b // comment-b2
 class a1
   extends b // comment
   implements z {
+
   constructor() {}
 }
 
@@ -96,6 +97,7 @@ class a3
   extends b
   // comment
   implements z, y {
+
   constructor() {}
 }
 
@@ -234,12 +236,14 @@ class G1<T> implements IPoly<T> {
 
 class G2<T> // g2
   implements IPoly<T> {
+
   x: T;
 }
 
 class G3<T> // g3
   extends U
   implements IPoly<T> {
+
   x: T;
 }
 
@@ -248,6 +252,7 @@ class G4<
   >
   extends U
   implements IPoly<T> {
+
   x: T;
 }
 

--- a/tests/typescript/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/classes/__snapshots__/jsfmt.spec.js.snap
@@ -42,10 +42,29 @@ export class VisTimelineComponent2
 	implements AfterViewInit, OnChanges, OnDestroy, AndSomethingReallyReallyLong {
 }
 
+class loooooooooooooooooooong extends looooooooooooooooooong implements loooooooooooooooooooong {
+  // leading comment
+  property: string;
+}
+
+class loooooooooooooooooooong extends looooooooooooooooooong implements loooooooooooooooooooong {
+  property: string;
+}
+
+class loooooooooooooooooooong extends looooooooooooooooooong implements loooooooooooooooooooong {
+
+  property: string;
+}
+
+class loooooooooooooooooooong extends looooooooooooooooooong implements loooooooooooooooooooong, loooooooooooooooooooong, loooooooooooooooooooong {
+  property: string;
+}
+
 =====================================output=====================================
 class MyContractSelectionWidget
   extends React.Component<void, MyContractSelectionWidgetPropsType, void>
   implements SomethingLarge {
+
   method() {}
 }
 
@@ -86,6 +105,36 @@ export class VisTimelineComponent2
     OnChanges,
     OnDestroy,
     AndSomethingReallyReallyLong {}
+
+class loooooooooooooooooooong
+  extends looooooooooooooooooong
+  implements loooooooooooooooooooong {
+  // leading comment
+  property: string;
+}
+
+class loooooooooooooooooooong
+  extends looooooooooooooooooong
+  implements loooooooooooooooooooong {
+
+  property: string;
+}
+
+class loooooooooooooooooooong
+  extends looooooooooooooooooong
+  implements loooooooooooooooooooong {
+
+  property: string;
+}
+
+class loooooooooooooooooooong
+  extends looooooooooooooooooong
+  implements
+    loooooooooooooooooooong,
+    loooooooooooooooooooong,
+    loooooooooooooooooooong {
+  property: string;
+}
 
 ================================================================================
 `;

--- a/tests/typescript/classes/break.ts
+++ b/tests/typescript/classes/break.ts
@@ -33,3 +33,21 @@ export class VisTimelineComponent
 export class VisTimelineComponent2
 	implements AfterViewInit, OnChanges, OnDestroy, AndSomethingReallyReallyLong {
 }
+
+class loooooooooooooooooooong extends looooooooooooooooooong implements loooooooooooooooooooong {
+  // leading comment
+  property: string;
+}
+
+class loooooooooooooooooooong extends looooooooooooooooooong implements loooooooooooooooooooong {
+  property: string;
+}
+
+class loooooooooooooooooooong extends looooooooooooooooooong implements loooooooooooooooooooong {
+
+  property: string;
+}
+
+class loooooooooooooooooooong extends looooooooooooooooooong implements loooooooooooooooooooong, loooooooooooooooooooong, loooooooooooooooooooong {
+  property: string;
+}


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Finding heuristics.

The following class can be difficult to read because the beginning of the member declaration is confusing.

```ts
class loooooooooooooooooooong
  extends looooooooooooooooooong
  implements loooooooooooooooooooong {
  property1: string;
  property2: string;
  property3: string;
  property4: string;
}

```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
